### PR TITLE
Fix breakage on Thunderbird 128+ and trim excess permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,17 +11,7 @@
     }
   },
 	"permissions": [
-			"messagesRead",
-			"messagesUpdate",
-			"accountsRead",
-			"storage",
-			"menus",
-			"compose",
-			"tabs",
-			"activeTab",
-			"management",
-			"notifications",
-			"messagesModify"
+		"storage"
 	],
   "experiment_apis": {
     "qfns": {

--- a/qfns_implementation.js
+++ b/qfns_implementation.js
@@ -1,6 +1,6 @@
 (function (exports) {
-	let QuickFilterManager = ChromeUtils.import("resource:///modules/QuickFilterManager.jsm");
-	
+	const { QuickFilterManager } = ChromeUtils.importESModule("resource:///modules/QuickFilterManager.sys.mjs");
+
 	const lazy = {};
 	ChromeUtils.defineESModuleGetters(lazy, {
 		GlodaMsgSearcher: "resource:///modules/gloda/GlodaMsgSearcher.sys.mjs"
@@ -8,7 +8,7 @@
 
 	let prefs = {disable_upsell: false};
 
-	// based on https://hg.mozilla.org/comm-central/file/3838e278a13de2d802bf3892c205517723ec4780/mail/modules/QuickFilterManager.sys.mjs#l1190
+	// based on https://hg.mozilla.org/comm-central/file/tip/mail/modules/QuickFilterManager.sys.mjs
 	// only does a global search if the 'upsell' dialog is shown - meaning no results and the results have been shown
 	function searchOnlyWithNoResults(aState, aNode, aEvent, aDocument) {
 		const text = aEvent.detail || null;
@@ -18,7 +18,7 @@
 			if (upsell.state == "open" && prefs.disable_upsell == false) {
 				upsell.hidePopup();
 				const tabmail =
-					aDocument.ownerGlobal.top.document.getElementById("tabmail");
+					aDocument.documentGlobal.top.document.getElementById("tabmail");
 				tabmail.openTab("glodaFacet", {
 					searcher: new lazy.GlodaMsgSearcher(null, aState.text),
 				});
@@ -30,7 +30,7 @@
 		aDocument.getElementById("quick-filter-bar-filter-text-bar").hidden = !text;
 		return [aState, !isSearch];
 	};
-	
+
   class qfns extends ExtensionCommon.ExtensionAPI {
     onStartup() { }
     onShutdown(isAppShutdown) { }
@@ -41,8 +41,7 @@
 						prefs = p;
 					},
 					monkeyPatch: async function() {
-						// monkey patch onCommand, 
-						QuickFilterManager.QuickFilterManager.filterDefsByName["text"].onCommand = searchOnlyWithNoResults;
+						QuickFilterManager.filterDefsByName["text"].onCommand = searchOnlyWithNoResults;
 					}
 				}
 			}


### PR DESCRIPTION
QuickFilterManager.jsm was removed; switch to importESModule() with the .sys.mjs path. Update the double-dereference and the ownerGlobal -> documentGlobal tabmail lookup to match the current upstream source.

Reduce permissions from 11 entries to the single one actually used (storage).